### PR TITLE
chore: enable creation of issues from discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vega Protocol Feedback
+    url: https://github.com/vegaprotocol/feedback/discussions
+    about: Share your feedback with the Vega project team.


### PR DESCRIPTION
In order to be able to use the `Create issue from discussion` feature in GitHub we need to enable issues in the repo settings. As we do not want people to confuse adding issues and adding discussions this PR directs people adding new issues to the discussions page.

The process to move a discussion to an issue would be:
1. Create issue from discussion
2. Transfer the issue to the relevant repo

Note: Once this is merged there is a follow up task to enable issues on this repo.
