### PR TITLE
feat: add bug templates to discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking your time to file a bug report!
+        Thank you for taking the time to file a bug report!
 
   - type: textarea
     id: bug
@@ -34,7 +34,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: "Detail the steps to reproduce the behaviour"
+      description: "Detail the steps to reproduce the behaviour."
       value: |
         1. Go to '...'
         2. Click on '....'
@@ -50,7 +50,7 @@ body:
     id: has-id
     attributes:
       label: pub-key
-      description: Please add your vega pubkey to help investigations.
+      description: "Please add your Vega public key to help investigations."
     validations:
       required: false
 
@@ -58,7 +58,7 @@ body:
     id: system-info
     attributes:
       label: System information
-      description: "Add any other context about the problem here including; system version numbers, components affected."
+      description: "Add any other context about the problem here including system version numbers, components affected."
     validations:
       required: true
 
@@ -66,6 +66,6 @@ body:
     id: visual-info
     attributes:
       label: Screenshots and videos
-      description: "Add any other context about the problem here including; screenshots and videos."
+      description: "Add any other context about the problem here including screenshots and videos."
     validations:
       required: false

--- a/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
@@ -1,0 +1,71 @@
+title: "Bug Report: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking your time to file a bug report!
+
+  - type: textarea
+    id: bug
+    attributes:
+      label: Problem encountered
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: "A clear and concise description of how the system is behaving."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: "Detail the steps to reproduce the behaviour"
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Observe the error
+        ...
+      render: bash
+      render: bash
+    validations:
+      required: true
+
+  - type: input
+    id: has-id
+    attributes:
+      label: pub-key
+      description: Please add your vega pubkey to help investigations.
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: "Add any other context about the problem here including; system version numbers, components affected."
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual-info
+    attributes:
+      label: Screenshots and videos
+      description: "Add any other context about the problem here including; screenshots and videos."
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
@@ -52,7 +52,7 @@ body:
       label: pub-key
       description: Please add your vega pubkey to help investigations.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: system-info
@@ -68,4 +68,4 @@ body:
       label: Screenshots and videos
       description: "Add any other context about the problem here including; screenshots and videos."
     validations:
-      required: true
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/api-query-bugs.yml
@@ -47,12 +47,24 @@ body:
       required: true
 
   - type: input
-    id: has-id
+    id: pubkey
     attributes:
-      label: pub-key
+      label: Public key
       description: "Please add your Vega public key to help investigations."
     validations:
       required: false
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network affected
+      description: "Please specify the network affected to help investigations."
+      options:
+        - Mainnet
+        - Validator testnet
+        - Fairground
+    validations:
+      required: true
 
   - type: textarea
     id: system-info

--- a/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking your time to file a bug report!
+        Thank you for taking the time to file a bug report!
 
   - type: textarea
     id: bug
@@ -34,7 +34,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: "Detail the steps to reproduce the behaviour"
+      description: "Detail the steps to reproduce the behaviour."
       value: |
         1. Go to '...'
         2. Click on '....'
@@ -50,7 +50,7 @@ body:
     id: has-id
     attributes:
       label: pub-key
-      description: Please add your vega pubkey to help investigations.
+      description: "Please add your Vega public key to help investigations."
     validations:
       required: false
 
@@ -58,7 +58,7 @@ body:
     id: system-info
     attributes:
       label: System information
-      description: "Add any other context about the problem here including; system version numbers, components affected."
+      description: "Add any other context about the problem here including system version numbers, components affected."
     validations:
       required: true
 
@@ -66,6 +66,6 @@ body:
     id: visual-info
     attributes:
       label: Screenshots and videos
-      description: "Add any other context about the problem here including; screenshots and videos."
+      description: "Add any other context about the problem here including screenshots and videos."
     validations:
       required: false

--- a/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
@@ -47,12 +47,25 @@ body:
       required: true
 
   - type: input
-    id: has-id
+    id: pubkey
     attributes:
-      label: pub-key
+      label: Public key
       description: "Please add your Vega public key to help investigations."
     validations:
       required: false
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network affected
+      description: "Please specify the network affected to help investigations."
+      options:
+        - Mainnet
+        - Validator testnet
+        - Fairground
+        - Local / Vega Capsule
+    validations:
+      required: true
 
   - type: textarea
     id: system-info

--- a/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
@@ -1,0 +1,71 @@
+title: "Bug Report: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking your time to file a bug report!
+
+  - type: textarea
+    id: bug
+    attributes:
+      label: Problem encountered
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: "A clear and concise description of how the system is behaving."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: "Detail the steps to reproduce the behaviour"
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Observe the error
+        ...
+      render: bash
+      render: bash
+    validations:
+      required: true
+
+  - type: input
+    id: has-id
+    attributes:
+      label: pub-key
+      description: Please add your vega pubkey to help investigations.
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: "Add any other context about the problem here including; system version numbers, components affected."
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual-info
+    attributes:
+      label: Screenshots and videos
+      description: "Add any other context about the problem here including; screenshots and videos."
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/running-a-node-bugs.yml
@@ -52,7 +52,7 @@ body:
       label: pub-key
       description: Please add your vega pubkey to help investigations.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: system-info
@@ -68,4 +68,4 @@ body:
       label: Screenshots and videos
       description: "Add any other context about the problem here including; screenshots and videos."
     validations:
-      required: true
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
@@ -1,0 +1,71 @@
+title: "Bug Report: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking your time to file a bug report!
+
+  - type: textarea
+    id: bug
+    attributes:
+      label: Problem encountered
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: "A clear and concise description of how the system is behaving."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: "Detail the steps to reproduce the behaviour"
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Observe the error
+        ...
+      render: bash
+      render: bash
+    validations:
+      required: true
+
+  - type: input
+    id: has-id
+    attributes:
+      label: pub-key
+      description: Please add your vega pubkey to help investigations.
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: "Add any other context about the problem here including; system version numbers, components affected."
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual-info
+    attributes:
+      label: Screenshots and videos
+      description: "Add any other context about the problem here including; screenshots and videos."
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking your time to file a bug report!
+        Thank you for taking the time to file a bug report!
 
   - type: textarea
     id: bug
@@ -34,7 +34,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: "Detail the steps to reproduce the behaviour"
+      description: "Detail the steps to reproduce the behaviour."
       value: |
         1. Go to '...'
         2. Click on '....'
@@ -50,7 +50,7 @@ body:
     id: has-id
     attributes:
       label: pub-key
-      description: Please add your vega pubkey to help investigations.
+      description: "Please add your Vega public key to help investigations."
     validations:
       required: false
 

--- a/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
@@ -52,7 +52,7 @@ body:
       label: pub-key
       description: Please add your vega pubkey to help investigations.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: system-info
@@ -68,4 +68,4 @@ body:
       label: Screenshots and videos
       description: "Add any other context about the problem here including; screenshots and videos."
     validations:
-      required: true
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/token-dapp-and-console-bugs.yml
@@ -47,12 +47,24 @@ body:
       required: true
 
   - type: input
-    id: has-id
+    id: pubkey
     attributes:
-      label: pub-key
+      label: Public key
       description: "Please add your Vega public key to help investigations."
     validations:
       required: false
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network affected
+      description: "Please specify the network affected to help investigations."
+      options:
+        - Mainnet
+        - Validator testnet
+        - Fairground
+    validations:
+      required: true
 
   - type: textarea
     id: system-info

--- a/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking your time to file a bug report!
+        Thank you for taking the time to file a bug report!
 
   - type: textarea
     id: bug
@@ -34,7 +34,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: "Detail the steps to reproduce the behaviour"
+      description: "Detail the steps to reproduce the behaviour."
       value: |
         1. Go to '...'
         2. Click on '....'
@@ -50,7 +50,7 @@ body:
     id: has-id
     attributes:
       label: pub-key
-      description: Please add your vega pubkey to help investigations.
+      description: "Please add your Vega public key to help investigations."
     validations:
       required: false
 
@@ -58,7 +58,7 @@ body:
     id: system-info
     attributes:
       label: System information
-      description: "Add any other context about the problem here including; system version numbers, components affected."
+      description: "Add any other context about the problem here including which app you're using, version numbers, components affected."
     validations:
       required: true
 
@@ -66,6 +66,6 @@ body:
     id: visual-info
     attributes:
       label: Screenshots and videos
-      description: "Add any other context about the problem here including; screenshots and videos."
+      description: "Add any other context about the problem here including screenshots and videos."
     validations:
       required: false

--- a/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
@@ -47,18 +47,51 @@ body:
       required: true
 
   - type: input
-    id: has-id
+    id: pubkey
     attributes:
-      label: pub-key
+      label: Public key
       description: "Please add your Vega public key to help investigations."
     validations:
       required: false
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network affected
+      description: "Please specify the network affected to help investigations."
+      options:
+        - Mainnet
+        - Validator testnet
+        - Fairground
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: wallet-type
+    attributes:
+      label: Wallet type
+      description: "Please specify which wallet type the bug is applicable to."
+      options:
+        - label: CLI wallet
+        - label: Desktop wallet
+        - label: Node wallet (node operators)
+        - label: Browser wallet
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Wallet version
+      description: "Please add your Vega wallet version number e.g., 0.12.0."
+    validations:
+      required: true
 
   - type: textarea
     id: system-info
     attributes:
       label: System information
-      description: "Add any other context about the problem here including which app you're using, version numbers, components affected."
+      description: "Add any other context about the problem here including which app you're using and components affected."
     validations:
       required: true
 

--- a/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
@@ -1,0 +1,71 @@
+title: "Bug Report: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking your time to file a bug report!
+
+  - type: textarea
+    id: bug
+    attributes:
+      label: Problem encountered
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: "A clear and concise description of how the system is behaving."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: "Detail the steps to reproduce the behaviour"
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Observe the error
+        ...
+      render: bash
+      render: bash
+    validations:
+      required: true
+
+  - type: input
+    id: has-id
+    attributes:
+      label: pub-key
+      description: Please add your vega pubkey to help investigations.
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: "Add any other context about the problem here including; system version numbers, components affected."
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual-info
+    attributes:
+      label: Screenshots and videos
+      description: "Add any other context about the problem here including; screenshots and videos."
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/vega-wallet-bugs.yml
@@ -52,7 +52,7 @@ body:
       label: pub-key
       description: Please add your vega pubkey to help investigations.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: system-info
@@ -68,4 +68,4 @@ body:
       label: Screenshots and videos
       description: "Add any other context about the problem here including; screenshots and videos."
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
This PR adds templates for bugs for the following discussion sections:

- API queries
- Token/Console
- Running a node
- Wallets

Currently these all use the same template content (albeit they have to be separate files) - the content could be changed or updated per discussion.

Currently the following fields in the template are optional, the rest are required:
- pubkey
- screenshots videos